### PR TITLE
Remove `settings:set` use, provide minetest.conf.

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -1,0 +1,9 @@
+# Game-specific minetest.conf, to be overwritten by global config.
+#
+# This should not be modified by players/users, only developers.
+
+# Disable automatic day/time cycle
+time_speed=0
+# Reduce default view range, since it isn't really needed to be huge
+# for this game
+viewing_range=50

--- a/mods/tug_core/init.lua
+++ b/mods/tug_core/init.lua
@@ -36,9 +36,6 @@ local function save_metadata()
     storage:set_string("gamestate", minetest.serialize(tug_gamestate.g))
 end
 
-minetest.settings:set("time_speed", 0)
-minetest.settings:set("viewing_range", 50)
-
 -- fix
 ground_level = 8
 


### PR DESCRIPTION
Instead of overwriting global config, only set game defaults via minetest.conf file. This also adds some reasons why we might set X to Y in that file.